### PR TITLE
Refactor rename of TApplyFunction and removed reference to Sempare.Streams

### DIFF
--- a/src/Sempare.Streams.Types.pas
+++ b/src/Sempare.Streams.Types.pas
@@ -56,7 +56,7 @@ type
   // AInput is var rather than const [ref] to simplify what developers have to type.
   // It is a minor optimisation when records are used. Note that
   // you can change values in AInput, but changes to AInput itself will have no result.
-  TApplyFunction<TInput> = reference to procedure(var AInput: TInput);
+  TApplyProc<TInput> = reference to procedure(var AInput: TInput);
   FValueFilter = reference to function(const AValue: TValue): boolean;
 
   TExprType = (etUnary, etBinary, etField, etBoolean, etFilter);
@@ -126,6 +126,24 @@ type
     function IsTrue(const AValue: T): boolean;
   end;
 
+  /// <summary>
+  /// StreamRef attribute allows for referencing fields between a class definition and the metadata record.
+  /// </summary>
+  StreamFieldAttribute = class(TCustomAttribute)
+  private
+    FName: string;
+  public
+    constructor Create(const AName: string);
+    property name: string read FName;
+  end;
+
 implementation
+
+{ StreamFieldAttribute }
+
+constructor StreamFieldAttribute.Create(const AName: string);
+begin
+  FName := AName;
+end;
 
 end.

--- a/src/Sempare.Streams.pas
+++ b/src/Sempare.Streams.pas
@@ -274,12 +274,12 @@ type
     /// <summary>
     /// Apply applies a procedure to the items in the stream.
     /// <summary>
-    procedure Apply(const AFunction: TApplyFunction<T>);
+    procedure Apply(const AFunction: TApplyProc<T>);
 
     /// <summary>
     /// Update applies a procedure to the items in the stream. (Update is an alias for Apply);
     /// <summary>
-    procedure Update(const AFunction: TApplyFunction<T>); inline;
+    procedure Update(const AFunction: TApplyProc<T>); inline;
 
     /// <summary>
     /// Delete items from a target list based on values in the stream
@@ -536,16 +536,7 @@ type
     class function ReflectMetadata<TMetadata: record; T>(): TMetadata; static;
   end;
 
-  /// <summary>
-  /// StreamRef attribute allows for referencing fields between a class definition and the metadata record.
-  /// </summary>
-  StreamFieldAttribute = class(TCustomAttribute)
-  private
-    FName: string;
-  public
-    constructor Create(const AName: string);
-    property Name: string read FName;
-  end;
+  StreamFieldAttribute = Sempare.Streams.Types.StreamFieldAttribute;
 
 function Field(const AName: string): TFieldExpression; overload;
 function Field(const AName: string; const AOrder: TSortOrder): TSortExpression; overload;
@@ -1129,7 +1120,7 @@ begin
   result := TUniqueEnum<T>.Create(FEnum, AComparator);
 end;
 
-procedure TStreamOperation<T>.Update(const AFunction: TApplyFunction<T>);
+procedure TStreamOperation<T>.Update(const AFunction: TApplyProc<T>);
 begin
   Apply(AFunction);
 end;
@@ -1159,7 +1150,7 @@ begin
   result := Enum.Any<T>(FEnum, APredicate);
 end;
 
-procedure TStreamOperation<T>.Apply(const AFunction: TApplyFunction<T>);
+procedure TStreamOperation<T>.Apply(const AFunction: TApplyProc<T>);
 begin
   Enum.Apply<T>(FEnum, AFunction);
 end;
@@ -1278,13 +1269,6 @@ end;
 class function Stream.From<T>(ASource: System.IEnumerable<T>): TStreamOperation<T>;
 begin
   result := TIEnumerableEnum<T>.Create(ASource);
-end;
-
-{ StreamFieldAttribute }
-
-constructor StreamFieldAttribute.Create(const AName: string);
-begin
-  FName := AName;
 end;
 
 end.


### PR DESCRIPTION
Small refactoring.

Rename TApplyFunction to TApplyProc
Removed reference to Sempare.Streams in Sempare.Streams.Enum
Moved StreamFieldAttribute to Sempare.Streams.Types (to remove Sempare.Streams reference)
Reformatting code